### PR TITLE
Update brew install command (deprecated brew cask)

### DIFF
--- a/common_tools
+++ b/common_tools
@@ -398,7 +398,7 @@ check_adb_dependency(){
   if ! [ -x "$(command -v "adb")" ]; then
     echo "🤷‍ Android Debug Bridge required!"
     should_proceed "🔄 Install via homebrew? (this may take a while)"
-    brew cask install "android-platform-tools"
+    brew install --cask "android-platform-tools"
   fi
 }
 


### PR DESCRIPTION
Changed deprecated brew cask call to valid command option.
Tested on Catalina 10.15.7