### PR TITLE
Fix jq parse error on parallel iOS commands (iscreenshot -a)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+    🐛 iscreenshot -a (and other parallel iOS commands) no longer print
+       "jq: parse error: Invalid numeric literal" - device info now uses a
+       per-device temp file instead of one shared file that concurrent jobs
+       overwrote mid-read
+
   🎉 Version 1.5.0 - compatibility update for 2026: Android 16, iOS 17-26 and Apple Silicon
 
     🛠 Major compatibility fixes, verified on real hardware (iPhone 16 Pro / iOS 26, Pixel 6 / Android 16):

--- a/common_tools
+++ b/common_tools
@@ -373,12 +373,19 @@ ios_check_developer_image_and_pairing(){
 }
 
 ios_device_info(){
+  # Use a per-device temp file so parallel invocations (e.g. iscreenshot -a)
+  # don't overwrite each other's go-ios output mid-read, which garbled the JSON
+  # and caused "jq: parse error: Invalid numeric literal". The UDID is unique per
+  # device, so concurrent jobs never collide. Callees (ios_check_pairing,
+  # ios_check_developer_image) inherit this value via bash dynamic scope.
+  local TEMPORARY_FILE="$TEMPORARY_FILE-${1//[^A-Za-z0-9]/_}"
   ios_check_developer_image_and_pairing "$1"
   MANUFACTURER="Apple"
   go-ios info --udid="$1" > "$TEMPORARY_FILE"
   MODEL=$(ios_translate_name "$(cat "$TEMPORARY_FILE" | jq -r '.ProductType')")
   VERSION=$(cat "$TEMPORARY_FILE" | jq -r '.ProductVersion')
   INFO=$(printf "%s) %s %s %s - %s" "$NUMBER" "$MANUFACTURER" "$MODEL" "$VERSION" "$ID")
+  rm -f "$TEMPORARY_FILE"
 }
 
 ios_choose_device(){


### PR DESCRIPTION
## Problem

Running `iscreenshot -a` (or other parallel iOS commands) prints:

```
jq: parse error: Invalid numeric literal at line 2, column 30
```

Screenshots still save, but the error is printed for every-but-one device.

## Cause

All iOS commands share a **single** temp file for `go-ios` output:

```bash
# common_tools
TEMPORARY_FILE="/private/tmp/mobile-toolkit-cache"
```

`iscreenshot -a` runs `screenshot "$ID" &` per device concurrently. Each calls `ios_device_info`, which does `go-ios info > "$TEMPORARY_FILE"` and immediately reads it back with `jq`. With multiple devices, one job overwrites the file while another is mid-read → garbled/partial JSON → the `jq` parse error. Single-device runs never hit it (no concurrency).

## Fix

`ios_device_info` now uses a **per-device** temp file keyed by the (unique) UDID, so concurrent jobs never collide:

```bash
local TEMPORARY_FILE="$TEMPORARY_FILE-${1//[^A-Za-z0-9]/_}"
```

- Callees (`ios_check_pairing`, `ios_check_developer_image`) inherit the value via bash dynamic scope, so the whole chain stays consistent.
- The file is cleaned up (`rm -f`) afterwards.
- Matches the existing per-invocation temp-file idiom already used in `iinstall` and `irecord`.

## Testing

- `shellcheck` (with the CI-disabled rules `SC1090`/`SC2207`/`SC2001`/`SC1091`) reports **no new findings** vs. before the change.
- `changelog.txt` updated per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)